### PR TITLE
Improve WebSocket connection handling with timeout and watchdog

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,7 +46,6 @@ module.exports = function createPlugin(app) {
 
   plugin.start = function (options) {
     app.debug("AisStream Plugin Started");
-    resetWatchdog();
     if (!options.apiKey || !options.boundingBoxSize) {
       app.error("Missing required options: apiKey and boundingBoxSize are required.");
       return;
@@ -82,7 +81,16 @@ module.exports = function createPlugin(app) {
       socket = new WebSocket("wss://stream.aisstream.io/v0/stream");
       const API_KEY = options.apiKey;
 
+      const connectTimeout = setTimeout(() => {
+        if (socket && socket.readyState === WebSocket.CONNECTING) {
+          app.debug("WebSocket connection timeout, retrying...");
+          socket.terminate();
+        }
+      }, 15000);
+
       socket.addEventListener("open", () => {
+        clearTimeout(connectTimeout);
+        resetWatchdog();
         const subscriptionMessage = {
           APIkey: API_KEY,
           BoundingBoxes: [[
@@ -101,6 +109,7 @@ module.exports = function createPlugin(app) {
       });
 
       socket.addEventListener("close", (event) => {
+        clearTimeout(connectTimeout);
         app.debug(`WebSocket closed: code=${event.code} wasClean=${event.wasClean} reason=${event.reason || 'none'}`);
         socket = null;
         if (!event.wasClean) {


### PR DESCRIPTION
## Summary
Improved the reliability of WebSocket connections to the AIS Stream service by implementing a connection timeout mechanism and adjusting when the watchdog timer is reset.

## Key Changes
- **Added connection timeout**: Implemented a 15-second timeout that terminates the WebSocket connection if it fails to establish within that timeframe, triggering an automatic retry
- **Moved watchdog reset**: Relocated `resetWatchdog()` call from the `start()` function to the WebSocket `open` event handler, ensuring the watchdog only resets after a successful connection is established
- **Proper timeout cleanup**: Added `clearTimeout()` calls in both the `open` and `close` event handlers to prevent memory leaks from abandoned timeouts

## Implementation Details
- The connection timeout uses `socket.readyState === WebSocket.CONNECTING` to verify the socket is still in the connecting state before terminating
- The watchdog timer now only resets upon successful connection, preventing false positives during connection failures
- Timeout cleanup is handled in both success (`open`) and failure (`close`) scenarios to ensure proper resource management

https://claude.ai/code/session_01Bq9B7vGRkBdzJACvGJRBh8