### PR TITLE
Add immediate WebSocket startup with current position and ESLint

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,0 +1,19 @@
+import eslint from '@eslint/js';
+import tseslint from 'typescript-eslint';
+
+export default tseslint.config(
+  eslint.configs.recommended,
+  ...tseslint.configs.recommended,
+  {
+    files: ['src/**/*.ts'],
+    languageOptions: {
+      parserOptions: {
+        projectService: true,
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+  },
+  {
+    ignores: ['dist/', 'node_modules/', 'test/'],
+  },
+);

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "prepare": "npm run build",
     "test": "vitest run",
     "test:watch": "vitest",
+    "lint": "eslint src/",
     "prepublishOnly": "npm run build"
   },
   "keywords": [
@@ -26,10 +27,13 @@
   },
   "devDependencies": {
     "@aisstream/aisstream": "^1.0.0",
+    "@eslint/js": "^10.0.1",
     "@types/node": "^20.0.0",
     "@types/ws": "^8.5.0",
+    "eslint": "^10.1.0",
     "rimraf": "^6.0.0",
     "typescript": "^5.4.0",
+    "typescript-eslint": "^8.58.0",
     "vitest": "^3.0.0"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,6 +36,15 @@ function toBoundingBox(bounds: { latitude: number; longitude: number }[]): Bound
   ];
 }
 
+function isValidPosition(value: unknown): value is { latitude: number; longitude: number } {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    typeof (value as Record<string, unknown>).latitude === 'number' &&
+    typeof (value as Record<string, unknown>).longitude === 'number'
+  );
+}
+
 function createPlugin(app: SignalKApp): SignalKPlugin {
   const plugin: SignalKPlugin = {
     id: 'signalk-aisstream',
@@ -98,6 +107,23 @@ function createPlugin(app: SignalKApp): SignalKPlugin {
         onError: (msg) => app.error(msg),
       },
     );
+
+    // Attempt immediate start using current position if available
+    if (app.getSelfPath && messageTypes.length > 0) {
+      const position = app.getSelfPath('navigation.position');
+      if (isValidPosition(position)) {
+        app.debug('Position available at startup, starting WebSocket immediately');
+        oldLon = position.longitude;
+        oldLat = position.latitude;
+        boundingBox = toBoundingBox(
+          geolib.getBoundsOfDistance(
+            { lat: position.latitude, lon: position.longitude },
+            options.boundingBoxSize * 1000,
+          ),
+        );
+        wsManager.start(boundingBox);
+      }
+    }
 
     const localSubscription = {
       context: 'vessels.self',

--- a/src/types/signalk.ts
+++ b/src/types/signalk.ts
@@ -54,6 +54,7 @@ export interface SignalKApp {
   error: (msg: string) => void;
   setPluginStatus?: (msg: string) => void;
   setProviderStatus?: (msg: string) => void;
+  getSelfPath?: (path: string) => unknown;
   handleMessage: (pluginId: string, delta: SignalKDelta) => void;
   subscriptionmanager: {
     subscribe: (


### PR DESCRIPTION
## Summary
This PR adds the ability to start the WebSocket connection immediately at plugin initialization if the vessel's current position is available, eliminating the need to wait for the first position update. It also introduces ESLint configuration for code quality.

## Key Changes
- **Position validation**: Added `isValidPosition()` type guard function to safely validate position objects with latitude and longitude properties
- **Immediate startup logic**: Implemented automatic WebSocket connection startup during plugin initialization if a valid position is available via `app.getSelfPath('navigation.position')`
- **Bounding box calculation**: When position is available at startup, the initial bounding box is calculated immediately using the current position
- **Type safety**: Extended `SignalKApp` interface with optional `getSelfPath` method for retrieving navigation data
- **ESLint setup**: Added ESLint configuration with TypeScript support for code quality checks
- **Build scripts**: Added `lint` npm script to run ESLint on source files

## Implementation Details
- The position check only occurs if `app.getSelfPath` is available and there are message types configured
- The validation ensures type safety before using position data to initialize the WebSocket connection
- ESLint is configured to use recommended rules from both `@eslint/js` and `typescript-eslint` with TypeScript-aware parsing

https://claude.ai/code/session_01XffSQHLo9sXC8BiypZcxsF