### PR TITLE
Refactor position subscription with dynamic polling rate

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -64,6 +64,7 @@ function createPlugin(app: SignalKApp): SignalKPlugin {
   let oldLat: number | null = null;
   let boundingBox: BoundingBox | null = null;
   let wsManager: WebSocketManager | null = null;
+  let lastPositionCheck = 0;
 
   plugin.start = function (options: PluginOptions): void {
     app.debug('AisStream Plugin Started');
@@ -152,7 +153,17 @@ function createPlugin(app: SignalKApp): SignalKPlugin {
           const lat = u.values[0]?.value?.latitude ?? null;
 
           if (lon !== null && lat !== null) {
-            if (oldLon === null && oldLat === null && wsManager && !wsManager.isConnected && messageTypes.length > 0) {
+            const now = Date.now();
+            const connected = wsManager?.isConnected ?? false;
+
+            // Before initial connection: process immediately
+            // After connected: throttle to refreshRate
+            if (connected && now - lastPositionCheck < options.refreshRate * 1000) {
+              return;
+            }
+            lastPositionCheck = now;
+
+            if (oldLon === null && oldLat === null && wsManager && !connected && messageTypes.length > 0) {
               oldLon = lon;
               oldLat = lat;
               boundingBox = toBoundingBox(
@@ -166,14 +177,14 @@ function createPlugin(app: SignalKApp): SignalKPlugin {
               { lat, lon },
             );
 
-            if (wsManager && wsManager.isConnected && distance > distanceLimit && messageTypes.length > 0) {
+            if (wsManager && connected && distance > distanceLimit && messageTypes.length > 0) {
               oldLon = lon;
               oldLat = lat;
               boundingBox = toBoundingBox(
                 geolib.getBoundsOfDistance({ lat, lon }, options.boundingBoxSize * 1000),
               );
               wsManager.updateBoundingBox(boundingBox);
-            } else if (wsManager && !wsManager.isConnected && !wsManager.isReconnecting && messageTypes.length > 0) {
+            } else if (wsManager && !connected && !wsManager.isReconnecting && messageTypes.length > 0) {
               boundingBox = toBoundingBox(
                 geolib.getBoundsOfDistance({ lat, lon }, options.boundingBoxSize * 1000),
               );
@@ -199,6 +210,7 @@ function createPlugin(app: SignalKApp): SignalKPlugin {
     oldLon = null;
     oldLat = null;
     boundingBox = null;
+    lastPositionCheck = 0;
     app.debug('AisStream Plugin Stopped');
   };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -130,7 +130,7 @@ function createPlugin(app: SignalKApp): SignalKPlugin {
       subscribe: [
         {
           path: 'navigation.position',
-          period: options.refreshRate * 1000,
+          period: 1000,
         },
       ],
     };

--- a/src/index.ts
+++ b/src/index.ts
@@ -64,7 +64,6 @@ function createPlugin(app: SignalKApp): SignalKPlugin {
   let oldLat: number | null = null;
   let boundingBox: BoundingBox | null = null;
   let wsManager: WebSocketManager | null = null;
-  let lastPositionCheck = 0;
 
   plugin.start = function (options: PluginOptions): void {
     app.debug('AisStream Plugin Started');
@@ -126,76 +125,87 @@ function createPlugin(app: SignalKApp): SignalKPlugin {
       }
     }
 
-    const localSubscription = {
-      context: 'vessels.self',
-      subscribe: [
-        {
-          path: 'navigation.position',
-          period: 1000,
+    function subscribePosition(period: number): void {
+      // Clear any existing subscription
+      unsubscribes.forEach((f) => f());
+      unsubscribes = [];
+
+      const subscription = {
+        context: 'vessels.self',
+        subscribe: [
+          {
+            path: 'navigation.position',
+            period,
+          },
+        ],
+      };
+
+      app.subscriptionmanager.subscribe(
+        subscription,
+        unsubscribes,
+        (subscriptionError) => {
+          app.error('Subscription Error: ' + subscriptionError);
         },
-      ],
-    };
-
-    app.subscriptionmanager.subscribe(
-      localSubscription,
-      unsubscribes,
-      (subscriptionError) => {
-        app.error('Subscription Error: ' + subscriptionError);
-      },
-      (delta) => {
-        if (!delta || !delta.updates) {
-          app.error('Invalid delta received.');
-          return;
-        }
-
-        delta.updates.forEach((u) => {
-          const lon = u.values[0]?.value?.longitude ?? null;
-          const lat = u.values[0]?.value?.latitude ?? null;
-
-          if (lon !== null && lat !== null) {
-            const now = Date.now();
-            const connected = wsManager?.isConnected ?? false;
-
-            // Before initial connection: process immediately
-            // After connected: throttle to refreshRate
-            if (connected && now - lastPositionCheck < options.refreshRate * 1000) {
-              return;
-            }
-            lastPositionCheck = now;
-
-            if (oldLon === null && oldLat === null && wsManager && !connected && messageTypes.length > 0) {
-              oldLon = lon;
-              oldLat = lat;
-              boundingBox = toBoundingBox(
-                geolib.getBoundsOfDistance({ lat, lon }, options.boundingBoxSize * 1000),
-              );
-              wsManager.start(boundingBox);
-            }
-
-            const distance = haversine(
-              { lat: oldLat ?? lat, lon: oldLon ?? lon },
-              { lat, lon },
-            );
-
-            if (wsManager && connected && distance > distanceLimit && messageTypes.length > 0) {
-              oldLon = lon;
-              oldLat = lat;
-              boundingBox = toBoundingBox(
-                geolib.getBoundsOfDistance({ lat, lon }, options.boundingBoxSize * 1000),
-              );
-              wsManager.updateBoundingBox(boundingBox);
-            } else if (wsManager && !connected && !wsManager.isReconnecting && messageTypes.length > 0) {
-              boundingBox = toBoundingBox(
-                geolib.getBoundsOfDistance({ lat, lon }, options.boundingBoxSize * 1000),
-              );
-              wsManager.start(boundingBox);
-            } else if (messageTypes.length === 0) {
-              app.debug('No need to update AIS stream');
-            }
+        (delta) => {
+          if (!delta || !delta.updates) {
+            app.error('Invalid delta received.');
+            return;
           }
-        });
-      },
-    );
+
+          delta.updates.forEach((u) => {
+            const lon = u.values[0]?.value?.longitude ?? null;
+            const lat = u.values[0]?.value?.latitude ?? null;
+
+            if (lon !== null && lat !== null) {
+              if (oldLon === null && oldLat === null && wsManager && !wsManager.isConnected && messageTypes.length > 0) {
+                oldLon = lon;
+                oldLat = lat;
+                boundingBox = toBoundingBox(
+                  geolib.getBoundsOfDistance({ lat, lon }, options.boundingBoxSize * 1000),
+                );
+                wsManager.start(boundingBox);
+                // Switch to normal refresh rate now that we're connected
+                if (period !== options.refreshRate * 1000) {
+                  app.debug(`Switching position subscription to ${options.refreshRate}s interval`);
+                  subscribePosition(options.refreshRate * 1000);
+                }
+                return;
+              }
+
+              const distance = haversine(
+                { lat: oldLat ?? lat, lon: oldLon ?? lon },
+                { lat, lon },
+              );
+
+              if (wsManager && wsManager.isConnected && distance > distanceLimit && messageTypes.length > 0) {
+                oldLon = lon;
+                oldLat = lat;
+                boundingBox = toBoundingBox(
+                  geolib.getBoundsOfDistance({ lat, lon }, options.boundingBoxSize * 1000),
+                );
+                wsManager.updateBoundingBox(boundingBox);
+              } else if (wsManager && !wsManager.isConnected && !wsManager.isReconnecting && messageTypes.length > 0) {
+                boundingBox = toBoundingBox(
+                  geolib.getBoundsOfDistance({ lat, lon }, options.boundingBoxSize * 1000),
+                );
+                wsManager.start(boundingBox);
+                // Switch to normal refresh rate once reconnected
+                if (period !== options.refreshRate * 1000) {
+                  app.debug(`Switching position subscription to ${options.refreshRate}s interval`);
+                  subscribePosition(options.refreshRate * 1000);
+                }
+              } else if (messageTypes.length === 0) {
+                app.debug('No need to update AIS stream');
+              }
+            }
+          });
+        },
+      );
+    }
+
+    // Start with fast 1s polling to get position ASAP, then switch to refreshRate
+    const initialPeriod = wsManager.isConnected ? options.refreshRate * 1000 : 1000;
+    subscribePosition(initialPeriod);
   };
 
   plugin.stop = function (): void {
@@ -210,7 +220,6 @@ function createPlugin(app: SignalKApp): SignalKPlugin {
     oldLon = null;
     oldLat = null;
     boundingBox = null;
-    lastPositionCheck = 0;
     app.debug('AisStream Plugin Stopped');
   };
 


### PR DESCRIPTION
## Summary
Refactored the position subscription logic to support dynamic polling rates, enabling faster initial position acquisition followed by a switch to the configured refresh rate once connected.

## Key Changes
- Extracted position subscription logic into a reusable `subscribePosition(period)` function that accepts a configurable polling period
- Implemented automatic subscription cleanup and recreation when the polling period changes
- Added logic to start with aggressive 1-second polling if not already connected, then switch to the configured `refreshRate` once the WebSocket manager connects
- Added debug logging when switching between polling rates for better observability
- Improved code organization by consolidating subscription management into a single function

## Implementation Details
- The `subscribePosition()` function clears any existing subscriptions before creating new ones to prevent subscription leaks
- Initial polling period is determined by checking `wsManager.isConnected`: uses 1 second if disconnected, otherwise uses the configured `refreshRate`
- When the WebSocket manager successfully connects or reconnects, the subscription automatically switches to the normal refresh rate via recursive calls to `subscribePosition()`
- The polling rate adjustment happens transparently within the delta update handler, ensuring smooth transitions without manual intervention

https://claude.ai/code/session_01UKX2qh2cwQLNDngfVoVUpH